### PR TITLE
Add restError handler to allow rejecting error when no codes passed

### DIFF
--- a/examples/examples.ts
+++ b/examples/examples.ts
@@ -29,7 +29,7 @@ import { Fetcher } from '../src/fetcher';
       async (res) => ({ code: +res.headers.get('x-code')!, correlationId: res.headers.get('x-correlation-id')! }),
     )
     .handle(401, ([err, permission]) => `You lack ${permission}. Also, ${err.message}`)
-    .discardRest(() => '42')
+    .discardRestAsTo(() => '42')
     .map((s) => s.length)
     .run();
 


### PR DESCRIPTION
Currently discardRest method always returns Either.right as a fallback, this PR address this and adds posibility to reject with Either.Left